### PR TITLE
Cope with API change for getVarFlag.

### DIFF
--- a/libexec/bb-show
+++ b/libexec/bb-show
@@ -31,7 +31,7 @@ def format_variable(data, variable, flag=None, shell=False, show_unexpanded=True
         unexpanded = data.getVar(variable, False)
         pattern = '%s=%%s' % variable
 
-    if data.getVarFlag(variable, 'unexport'):
+    if data.getVarFlag(variable, 'unexport', expand=False):
         if flag:
             return pattern % unexpanded
         else:
@@ -50,7 +50,7 @@ def format_variable(data, variable, flag=None, shell=False, show_unexpanded=True
         if show_unexpanded and unexpanded != expanded:
             message += '# ' + pattern % unexpanded + '\n'
 
-        if data.getVarFlag(variable, 'export'):
+        if data.getVarFlag(variable, 'export', expand=False):
             message += 'export '
 
         if isinstance(expanded, basestring):
@@ -63,7 +63,7 @@ def format_variable(data, variable, flag=None, shell=False, show_unexpanded=True
 
 ignored_flags = ('func', 'python', 'export', 'export_func')
 def print_variable_flags(data, variable, show_unexpanded=True):
-    flags = data.getVarFlags(variable)
+    flags = data.getVarFlags(variable, expand=False)
     if not flags:
         return
 
@@ -81,7 +81,7 @@ def print_variable(data, variable, show_unexpanded=True):
     unexpanded = str(unexpanded)
 
 
-    flags = data.getVarFlags(variable) or {}
+    flags = data.getVarFlags(variable, expand=False) or {}
     if flags.get('func'):
         if flags.get('python'):
             print("python %s () {\n%s}\n" % (variable, unexpanded))
@@ -99,7 +99,7 @@ def print_variable(data, variable, show_unexpanded=True):
 
 def variable_function_deps(data, variable, deps, seen):
     variable_deps = deps and deps.get(variable) or set()
-    if data.getVarFlag(variable, 'python'):
+    if data.getVarFlag(variable, 'python', expand=False):
         # TODO: Fix generate_dependencies to return python function
         # execs dependencies, which seem to be missing for some reason
         parser = bb.codeparser.PythonParser(variable, logger)
@@ -112,7 +112,7 @@ def variable_function_deps(data, variable, deps, seen):
             continue
         seen.add(dep)
 
-        if data.getVarFlag(dep, 'func'):
+        if data.getVarFlag(dep, 'func', expand=False):
             for _dep in variable_function_deps(data, dep, deps, seen):
                 yield _dep
             yield dep
@@ -131,10 +131,10 @@ def dep_ordered_variables(data, variables, deps):
 def sorted_variables(data, variables=None, show_deps=True):
     def key(v):
         # Order: unexported vars, exported vars, shell funcs, python funcs
-        if data.getVarFlag(v, 'func'):
-            return int(bool(data.getVarFlag(v, 'python'))) + 2
+        if data.getVarFlag(v, 'func', expand=False):
+            return int(bool(data.getVarFlag(v, 'python', expand=False))) + 2
         else:
-            return int(bool(data.getVarFlag(v, 'export')))
+            return int(bool(data.getVarFlag(v, 'export', expand=False)))
 
     all_variables = data.keys()
     if not variables:


### PR DESCRIPTION
As of bitbake commit 4e5e501155a21fe64a470c626b3afe6d9748308e, the
expand flag no longer has a default value, as upstream plans on moving
from a default value of expand=False to a value of expand=True.

This commit makes all of the expand=False values explicit, allowing
us to work with the latest bitbake.

(See: http://git.yoctoproject.org/cgit.cgi/poky/commit/?id=4e5e501155a21fe64a470c626b3afe6d9748308e)