### PR TITLE
bb-whatdepends: check runtime dependees as well

### DIFF
--- a/libexec/bb-whatdepends
+++ b/libexec/bb-whatdepends
@@ -35,12 +35,23 @@ def whatdepends(args):
     filename = provmap.get(args.target)
 
     if args.recursive:
-        for dep_fn, depth in tinfoil.rec_get_dependees(filename, seen=[filename]):
+        seen = set([filename])
+        for dep_fn, depth in tinfoil.rec_get_dependees(filename, seen=seen):
+            dep_target = tinfoil.cache_data.pkg_fn[dep_fn]
+            print('  '*depth + dep_target)
+
+        for dep_fn, depth in tinfoil.rec_get_rdependees(filename, seen=seen):
             dep_target = tinfoil.cache_data.pkg_fn[dep_fn]
             print('  '*depth + dep_target)
     else:
         seen = set([filename])
         for dep_fn in tinfoil.get_dependees(filename):
+            dep_target = tinfoil.cache_data.pkg_fn[dep_fn]
+            if dep_target not in seen:
+                seen.add(dep_target)
+                print(dep_target)
+
+        for dep_fn in tinfoil.get_rdependees(filename):
             dep_target = tinfoil.cache_data.pkg_fn[dep_fn]
             if dep_target not in seen:
                 seen.add(dep_target)

--- a/libexec/bbcmd.py
+++ b/libexec/bbcmd.py
@@ -108,6 +108,27 @@ class Tinfoil(bb.tinfoil.Tinfoil):
                 dependees |= set(self.taskdata.get_dependees(target))
         return dependees
 
+    def rec_get_rdependees(self, fn, depth=0, seen=None):
+        if seen is None:
+            seen = set()
+
+        dependees = self.get_rdependees(fn) or []
+        for dependee in dependees:
+            if dependee in seen:
+                continue
+            seen.add(dependee)
+            yield dependee, depth
+
+            for _dependee, _depth in self.rec_get_rdependees(dependee, depth+1, seen):
+                yield _dependee, _depth
+
+    def get_rdependees(self, fn):
+        dependees = set()
+        for target, fns in self.taskdata.run_targets.items():
+            if fns and fns[0] == fn:
+                dependees |= set(self.taskdata.get_rdependees(target))
+        return dependees
+
     def get_filename(self, target):
         if not self.taskdata.have_build_target(target):
             if target in self.cooker.recipecache.ignored_dependencies:


### PR DESCRIPTION
This fixes a long standing weakness of the tool, it didn't check runtime dependencies, which made it of limited usefulness for images. Now it does, ex.:

    $ bb whatdepends -r busybox core-image-base
    Parsing recipes..done.
    packagegroup-core-boot
      core-image-base
      packagegroup-base

This pull req depends on the python 3 / runqueue fixes.