### PR TITLE
bbcmd: don't return None from rec_get_dependees

### DIFF
--- a/libexec/bbcmd.py
+++ b/libexec/bbcmd.py
@@ -91,10 +91,7 @@ class Tinfoil(bb.tinfoil.Tinfoil):
         if seen is None:
             seen = set()
 
-        dependees = self.get_dependees(fn)
-        if not dependees:
-            return
-
+        dependees = self.get_dependees(fn) or []
         for dependee in dependees:
             if dependee in seen:
                 continue


### PR DESCRIPTION
Signed-off-by: Christopher Larson <chris_larson@mentor.com>